### PR TITLE
Fix - Campos extras do log não carregam valor

### DIFF
--- a/src/Horse.Logger.Provider.LogFile.pas
+++ b/src/Horse.Logger.Provider.LogFile.pas
@@ -149,7 +149,7 @@ begin
       for I := 0 to Pred(LLogCache.Count) do
       begin
         LLog := LLogCache.Items[I] as THorseLoggerLog;
-        LParams := THorseLoggerUtils.GetFormatParams(DEFAULT_HORSE_LOG_FORMAT);
+        LParams := THorseLoggerUtils.GetFormatParams(FConfig.FLogFormat);
         for Z := Low(LParams) to High(LParams) do
         begin
 {$IFDEF FPC}


### PR DESCRIPTION
GetFormatParams estava pegando da const DEFAULT_HORSE_LOG_FORMAT então quando usuário personalizava o LogFormat os valores não eram salvos no log.


